### PR TITLE
Multiple cameras

### DIFF
--- a/launch/sc.yaml
+++ b/launch/sc.yaml
@@ -1,4 +1,4 @@
-sc:
+
   vis_enable: false
   ir_enable: false
   depth_enable: true

--- a/launch/sc.yaml
+++ b/launch/sc.yaml
@@ -1,4 +1,4 @@
-
+sc:
   vis_enable: false
   ir_enable: false
   depth_enable: true

--- a/launch/sc_multicam.launch
+++ b/launch/sc_multicam.launch
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<launch>
+	<rosparam command="load" file="$(find struct_core_ros)/launch/sc.yaml"/>
+	<node pkg="struct_core_ros" type="sc" name="camera1" output="screen">
+	     <param name="serial_number" type="str" value="2010" />
+    </node>
+    <node pkg="struct_core_ros" type="sc" name="camera2" output="screen">
+	     <param name="serial_number" type="str" value="2001" />
+    </node>
+</launch>

--- a/src/sc.cpp
+++ b/src/sc.cpp
@@ -394,23 +394,26 @@ public:
 	SCNode()  : nh_("~")
 	{
 
-		ros::param::param<bool>("~vis_enable", vis_enable_, false);
+		ros::param::param<bool>("vis_enable", vis_enable_, false);
 		ROS_INFO_STREAM(NODE_NAME << ": vis_enable = " << vis_enable_);
 
-		ros::param::param<bool>("~ir_enable", ir_enable_, false);
+		ros::param::param<bool>("ir_enable", ir_enable_, false);
 		ROS_INFO_STREAM(NODE_NAME << ": ir_enable = " << ir_enable_);
 
-		ros::param::param<bool>("~depth_enable", depth_enable_, false);
+		ros::param::param<bool>("depth_enable", depth_enable_, false);
 		ROS_INFO_STREAM(NODE_NAME << ": depth_enable = " << depth_enable_);
 
-		ros::param::param<bool>("~imu_enable", imu_enable_, false);
+		ros::param::param<bool>("imu_enable", imu_enable_, false);
 		ROS_INFO_STREAM(NODE_NAME << ": imu_enable = " << imu_enable_);
 
 		std::string frame_id;
-		ros::param::param<std::string>("~frame_id", frame_id, DEFAULT_FRAME_ID);
+		std::string node_name = ros::this_node::getName();
+		node_name = node_name.erase(0,1);
+		std::string default_frame_id = (node_name + "_FLU").c_str();
+		ros::param::param<std::string>("frame_id", frame_id, default_frame_id);
 		ROS_INFO_STREAM(NODE_NAME << ": frame_id = " << frame_id);
 
-    ros::param::param<bool>("~autoexposure_enable", autoexposure_enable_, true);
+    ros::param::param<bool>("autoexposure_enable", autoexposure_enable_, true);
 		ROS_INFO_STREAM(NODE_NAME << ": autoexposure_enable = " << autoexposure_enable_);
 
 		ST::CaptureSessionSettings::StructureCoreSettings scConfig;

--- a/src/sc.cpp
+++ b/src/sc.cpp
@@ -381,7 +381,9 @@ private:
 
 	bool imu_enable_;
 
-  bool autoexposure_enable_;
+    bool autoexposure_enable_;
+
+    std::string serial_number_;
 
 	SessionDelegate *delegate_ = nullptr;
 	ST::CaptureSessionSettings sessionConfig_;
@@ -406,15 +408,20 @@ public:
 		ros::param::param<bool>("imu_enable", imu_enable_, false);
 		ROS_INFO_STREAM(NODE_NAME << ": imu_enable = " << imu_enable_);
 
+		ros::param::param<bool>("autoexposure_enable", autoexposure_enable_, true);
+		ROS_INFO_STREAM(NODE_NAME << ": autoexposure_enable = " << autoexposure_enable_);
+
 		std::string frame_id;
 		std::string node_name = ros::this_node::getName();
 		node_name = node_name.erase(0,1);
 		std::string default_frame_id = (node_name + "_FLU").c_str();
-		ros::param::param<std::string>("frame_id", frame_id, default_frame_id);
+		ros::param::param<std::string>("~frame_id", frame_id, default_frame_id);
 		ROS_INFO_STREAM(NODE_NAME << ": frame_id = " << frame_id);
 
-    ros::param::param<bool>("autoexposure_enable", autoexposure_enable_, true);
-		ROS_INFO_STREAM(NODE_NAME << ": autoexposure_enable = " << autoexposure_enable_);
+		ros::param::param<std::string>("~serial_number", serial_number_, "null");
+		ROS_INFO_STREAM(NODE_NAME << ": serial_number = " << serial_number_);
+
+
 
 		ST::CaptureSessionSettings::StructureCoreSettings scConfig;
 
@@ -427,6 +434,9 @@ public:
 		scConfig.infraredFramerate = 15.f;
 		scConfig.depthFramerate    = 15.f;
 		scConfig.visibleFramerate  = 15.f;
+		if(serial_number_.compare("null") != 0){
+			scConfig.sensorSerial = serial_number_.c_str();
+		}
 
 		scConfig.depthResolution = ST::StructureCoreDepthResolution::VGA;
 		scConfig.visibleResolution = ST::StructureCoreVisibleResolution::Default;

--- a/src/sc.cpp
+++ b/src/sc.cpp
@@ -396,19 +396,19 @@ public:
 	SCNode()  : nh_("~")
 	{
 
-		ros::param::param<bool>("vis_enable", vis_enable_, false);
+		ros::param::param<bool>("sc/vis_enable", vis_enable_, false);
 		ROS_INFO_STREAM(NODE_NAME << ": vis_enable = " << vis_enable_);
 
-		ros::param::param<bool>("ir_enable", ir_enable_, false);
+		ros::param::param<bool>("sc/ir_enable", ir_enable_, false);
 		ROS_INFO_STREAM(NODE_NAME << ": ir_enable = " << ir_enable_);
 
-		ros::param::param<bool>("depth_enable", depth_enable_, false);
+		ros::param::param<bool>("sc/depth_enable", depth_enable_, false);
 		ROS_INFO_STREAM(NODE_NAME << ": depth_enable = " << depth_enable_);
 
-		ros::param::param<bool>("imu_enable", imu_enable_, false);
+		ros::param::param<bool>("sc/imu_enable", imu_enable_, false);
 		ROS_INFO_STREAM(NODE_NAME << ": imu_enable = " << imu_enable_);
 
-		ros::param::param<bool>("autoexposure_enable", autoexposure_enable_, true);
+		ros::param::param<bool>("sc/autoexposure_enable", autoexposure_enable_, true);
 		ROS_INFO_STREAM(NODE_NAME << ": autoexposure_enable = " << autoexposure_enable_);
 
 		std::string frame_id;


### PR DESCRIPTION
Enable cameras to have different names, which are reflected also in the frame convention
Add serial number support to be able to launch multiple ones